### PR TITLE
Nog meer verboden tekens toegevoegd

### DIFF
--- a/Export-SchoolDataSync.ps1
+++ b/Export-SchoolDataSync.ps1
@@ -100,7 +100,7 @@ Function Write-Log {
     Write-Host $log
 }
 
-$illegal_characters = "[^\S]|[\~\""\#\%\&\*\:\<\>\?\/\\{\|}\.]"
+$illegal_characters = "[^\S]|[\~\""\#\%\&\*\:\<\>\?\/\\{\|}\.\[\]]"
 $safe_character = "_"
 function ConvertTo-SISID([string]$Naam) {
     return $Naam -replace $illegal_characters, $safe_character


### PR DESCRIPTION
De tekens [ en ] in de naam van lesgroepen of klassen geven ook problemen bij het importeren van de CSV-bestanden. Deze change wijzigt [ en ] naar _.